### PR TITLE
feat: Add `set_as_inventory_for` api function

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,10 +426,11 @@ example_inventory:set_as_inventory_for(player, new_context)
 
 While the form will of course be cleared when the player leaves, if you'd like
 to unset the inventory manually, call `:unset_as_inventory_for(player)`,
-analogue to `close_hud`.:
+analogue to `close_hud`:
 
 ```lua
 example_inventory:unset_as_inventory_for(player)
 ```
 
-This will set the inventory formspec string to `""`.
+This will set the inventory formspec string to `""` and stop flow from
+processing inventory formspec input.

--- a/README.md
+++ b/README.md
@@ -403,7 +403,8 @@ gui.Stack{
 ### Set form as player inventory
 
 A form can be set as the player inventory. Flow internally generates the
-formspec and passes it to `player:set_inventory_formspec()`.
+formspec and passes it to `player:set_inventory_formspec()`. This will override
+your inventory mod.
 
 ```lua
 local example_inventory = flow.make_gui(function (player, context)
@@ -415,7 +416,8 @@ end)
 ```
 
 Like with the `show_hud` function, `update*` functions don't do anything, so to
-update it, call `set_as_inventory_for` again with the new context.
+update it, call `set_as_inventory_for` again with the new context. If the
+context is not provided, it will reuse the existing context.
 
 ```lua
 example_inventory:set_as_inventory_for(player, new_context)

--- a/README.md
+++ b/README.md
@@ -403,8 +403,9 @@ gui.Stack{
 ### Set form as player inventory
 
 A form can be set as the player inventory. Flow internally generates the
-formspec and passes it to `player:set_inventory_formspec()`. This will override
-your inventory mod.
+formspec and passes it to `player:set_inventory_formspec()`. This will
+completely replace your inventory and isn't compatible with inventory mods like
+sfinv.
 
 ```lua
 local example_inventory = flow.make_gui(function (player, context)

--- a/README.md
+++ b/README.md
@@ -399,3 +399,34 @@ gui.Stack{
 ```
 
 ![Screenshot](https://user-images.githubusercontent.com/3182651/215946217-3705dbd1-4ec8-4aed-a9eb-381fecb2d8f2.png)
+
+### Set form as player inventory
+
+A form can be set as the player inventory. Flow internally generates the
+formspec and passes it to `player:set_inventory_formspec()`.
+
+```lua
+local example_inventory = flow.make_gui(function (player, context)
+    return gui.Label{ label = "Inventory goes here!" }
+end)
+minetest.register_on_joinplayer(function(player)
+    example_inventory:set_as_inventory_for(player)
+end)
+```
+
+Like with the `show_hud` function, `update*` functions don't do anything, so to
+update it, call `set_as_inventory_for` again with the new context.
+
+```lua
+example_inventory:set_as_inventory_for(player, new_context)
+```
+
+While the form will of course be cleared when the player leaves, if you'd like
+to unset the inventory manually, call `:unset_as_inventory_for(player)`,
+analogue to `close_hud`.:
+
+```lua
+example_inventory:unset_as_inventory_for(player)
+```
+
+This will set the inventory formspec string to `""`.

--- a/init.lua
+++ b/init.lua
@@ -765,7 +765,8 @@ end
 local open_formspecs = {}
 local function show_form(self, player, formname, ctx, auto_name_id)
     local name = player:get_player_name()
-    local fs, form_info = prepare_form(self, player, formname, ctx, auto_name_id)
+    local fs, form_info = prepare_form(self, player, formname, ctx,
+        auto_name_id)
 
     open_formspecs[name] = form_info
     minetest.show_formspec(name, formname, fs)

--- a/init.lua
+++ b/init.lua
@@ -720,10 +720,12 @@ function Form:_render(player, ctx, formspec_version, id1)
         "Changing the value of ctx.form is not supported!")
     ctx.form = orig_form
 
+    -- The numbering of automatically named elements is continued from previous
+    -- iterations of the form to work around race conditions
+    if not id1 or id1 > 1e6 then id1 = 0 end
+
     local tree = render_ast(box)
-    local callbacks, saved_fields, id2 = parse_callbacks(
-        tree, orig_form, id1 or 0
-    )
+    local callbacks, saved_fields, id2 = parse_callbacks(tree, orig_form, id1)
 
     local redraw_if_changed = {}
     for var in pairs(used_ctx_vars) do
@@ -832,15 +834,11 @@ function Form:unset_as_inventory_for(player)
     end
 end
 
+-- This function may eventually call minetest.update_formspec if/when it gets
+-- added (https://github.com/minetest/minetest/issues/13142)
 local function update_form(self, player, form_info)
-    -- The numbering of automatically named elements is continued from previous
-    -- iterations of the form to work around race conditions
-    local auto_name_id
-    if form_info.auto_name_id < 1e6 then
-        auto_name_id = form_info.auto_name_id
-    end
-
-    show_form(self, player, form_info.formname, form_info.ctx, auto_name_id)
+    show_form(self, player, form_info.formname, form_info.ctx,
+        form_info.auto_name_id)
 end
 
 function Form:update(player)

--- a/init.lua
+++ b/init.lua
@@ -796,8 +796,14 @@ end
 local open_inv_formspecs = {}
 function Form:set_as_inventory_for(player, ctx)
     local name = player:get_player_name()
+    local old_form_info = open_inv_formspecs[name]
+    if not ctx and old_form_info and old_form_info.self == self then
+        ctx = old_form_info.ctx
+    end
+
     -- Formname of "" is inventory
-    local fs, form_info = prepare_form(self, player, "", ctx or {})
+    local fs, form_info = prepare_form(self, player, "", ctx or {},
+        old_form_info and old_form_info.auto_name_id)
 
     open_inv_formspecs[name] = form_info
     player:set_inventory_formspec(fs)

--- a/init.lua
+++ b/init.lua
@@ -843,8 +843,7 @@ local function update_form(self, player, form_info)
 end
 
 function Form:update(player)
-    local player_name = player:get_player_name()
-    local form_info = open_formspecs[player_name]
+    local form_info = open_formspecs[player:get_player_name()]
     if form_info and form_info.self == self then
         update_form(self, player, form_info)
     end

--- a/init.lua
+++ b/init.lua
@@ -917,8 +917,9 @@ local function on_fs_input(player, formname, fields)
 end
 
 local function on_leaveplayer(player)
-    open_formspecs[player:get_player_name()] = nil
-    open_inv_formspecs[player:get_player_name()] = nil
+    local name = player:get_player_name()
+    open_formspecs[name] = nil
+    open_inv_formspecs[name] = nil
 end
 
 if DEBUG_MODE then

--- a/init.lua
+++ b/init.lua
@@ -823,8 +823,12 @@ function Form:close_hud(player)
 end
 
 function Form:unset_as_inventory_for(player)
-    open_inv_formspecs[player:get_player_name()] = nil
-    player:set_inventory_formspec("") -- TODO should this restore what it was before? This disables inventory as-is until set by something else.
+    local name = player:get_player_name()
+    local form_info = open_inv_formspecs[name]
+    if form_info and form_info.self == self then
+        open_inv_formspecs[name] = nil
+        player:set_inventory_formspec("")
+    end
 end
 
 local function update_form(self, player, form_info)

--- a/init.lua
+++ b/init.lua
@@ -880,12 +880,13 @@ local function on_fs_input(player, formname, fields)
     for field, transformer in pairs(form_info.saved_fields) do
         if fields[field] then
             local new_value = transformer(fields[field])
-            if redraw_if_changed[field] and ctx_form[field] ~= new_value then
-                if DEBUG_MODE then
-                    print('Modified:', dump(field), dump(ctx_form[field]),
-                        '->', dump(new_value))
+            if ctx_form[field] ~= new_value then
+                if redraw_if_changed[field] then
+                    redraw_fs = true
+                elseif formname == "" then
+                    -- Update the inventory when the player closes it next
+                    form_info.ctx_form_modified = true
                 end
-                redraw_fs = true
             end
             ctx_form[field] = new_value
         end
@@ -902,7 +903,7 @@ local function on_fs_input(player, formname, fields)
 
     if formname == "" then
         -- Special case for inventory forms
-        if redraw_fs then
+        if redraw_fs or (fields.quit and form_info.ctx_form_modified) then
             form_info.self:set_as_inventory_for(player)
         end
     elseif fields.quit then

--- a/init.lua
+++ b/init.lua
@@ -759,7 +759,7 @@ local function prepare_form(self, player, formname, ctx, auto_name_id)
     -- if DEBUG_MODE then
     --     print(t3 - t, t2 - t, t3 - t2)
     -- end
-    return  fs, form_info
+    return fs, form_info
 end
 
 local open_formspecs = {}
@@ -864,14 +864,8 @@ end
 
 local function on_fs_input(player, formname, fields)
     local name = player:get_player_name()
-    local inv = false
-    local form_info
-    if formname ~= "" then
-        form_info = open_formspecs[name]
-    else
-        form_info = open_inv_formspecs[name]
-        inv = true
-    end
+    local form_infos = formname == "" and open_inv_formspecs or open_formspecs
+    local form_info = form_infos[name]
     if not form_info or formname ~= form_info.formname then return end
 
     local callbacks = form_info.callbacks
@@ -902,13 +896,14 @@ local function on_fs_input(player, formname, fields)
         end
     end
 
-    if inv then
-        if open_inv_formspecs[name] ~= form_info then return true end
-    else
-        if open_formspecs[name] ~= form_info then return true end
-    end
+    if form_infos[name] ~= form_info then return true end
 
-    if fields.quit and not inv then
+    if formname == "" then
+        -- Special case for inventory forms
+        if redraw_fs then
+            form_info.self:set_as_inventory_for(player)
+        end
+    elseif fields.quit then
         open_formspecs[name] = nil
     elseif redraw_fs then
         update_form(form_info.self, player, form_info)

--- a/test.lua
+++ b/test.lua
@@ -297,8 +297,6 @@ describe("Flow", function()
         assert(player:get_inventory_formspec() == "")
         stupid_simple_inv:set_as_inventory_for(player)
         assert(player:get_inventory_formspec() == stupid_simple_inv_expected)
-        stupid_simple_inv:update(player) -- TODO how do I show an update happened?
-        assert(player:get_inventory_formspec() == stupid_simple_inv_expected)
     end)
 
     it("can still show a form when an inventory formspec is shown", function ()


### PR DESCRIPTION
Adds the `Form:set_as_inventory_for(player, [ctx])` api.

Also includes

- `Form:unset_as_inventory_for(player)`
- Extends private `show_form` to account for inv edge cases
- ~~Extends `Form:update` to account for inv edge cases~~
- ~~Extends `Form:update_where` to account for inv edge cases~~
- Extends private `on_fs_input` to account for inv edge cases
- Adds abstraction functions
- Add feature to `on_leaveplayer` to delete the inv formspec as well
- Add a few unit tests for related features

see #1