### PR TITLE
feat: Add render_to_formspec_string function

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,10 +445,12 @@ the future.
 
 Some APIs in other mods, such as sfinv, expect formspec strings. You can use
 this API to embed flow forms inside them. To use flow with these mods, you can
-call `form:render_to_formspec_string(player, ctx, embedded)`.
+call `form:render_to_formspec_string(player, ctx, standalone)`.
 
- - When `embedded` is set, the `formspec_version` and `size` elements aren't
-   included in the returned formspec and are included in a third return value.
+ - By default the the `formspec_version` and `size` elements aren't included in
+   the returned formspec and are included in a third return value. Set
+   `standalone` to include them in the returned formspec string. The third
+   return value will not be returned.
  - Returns `formspec, process_event[, info]`
  - The `process_event(fields)` callback will return true if the formspec should
    be redrawn, where `render_to_formspec_string` should be called and the new

--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ processing inventory formspec input.
 This API should only be used when necessary and may have breaking changes in
 the future.
 
-Some APIs in other mods, such as sfinv, expect formspec strings, you can use
+Some APIs in other mods, such as sfinv, expect formspec strings. You can use
 this API to embed flow forms inside them. To use flow with these mods, you can
 call `form:render_to_formspec_string(player, ctx, embedded)`.
 

--- a/README.md
+++ b/README.md
@@ -364,19 +364,20 @@ gui.Button{
 },
 ```
 
-## Experimental features
+The style elements are invisible and won't affect padding.
 
-These features might be broken in the future.
-
-### Hiding elements
+## Hiding elements
 
 Elements inside boxes can have `visible = false` set to hide them from the
 player. Elements hidden this way will still take up space like with
 `visibility: hidden;` in CSS.
 
-The style elements are invisible and won't affect padding.
+## Experimental features
 
-### `no_prepend[]`
+These features might be broken in the future.
+
+<details>
+<summary><h3><code>no_prepend[]</code></h3></summary>
 
 You can set `no_prepend = true` on the "root" element to disable formspec
 prepends.
@@ -400,7 +401,8 @@ end)
 
 ![Screenshot](https://user-images.githubusercontent.com/3182651/212222545-baee3669-15cd-410d-a638-c63b65a8811b.png)
 
-### Using a form as an inventory
+</details><details>
+<summary><h3>Using a form as an inventory</h3></summary>
 
 A form can be set as the player inventory. Flow internally generates the
 formspec and passes it to `player:set_inventory_formspec()`. This will
@@ -435,7 +437,8 @@ example_inventory:unset_as_inventory_for(player)
 This will set the inventory formspec string to `""` and stop flow from
 processing inventory formspec input.
 
-### Rendering to a formspec
+</details><details>
+<summary><h3>Rendering to a formspec</h3></summary>
 
 This API should only be used when necessary and may have breaking changes in
 the future.
@@ -454,3 +457,5 @@ call `form:render_to_formspec_string(player, ctx, embedded)`.
 
 
 **Do not use this API with node meta formspecs, it can and will break!**
+
+</details>

--- a/README.md
+++ b/README.md
@@ -434,3 +434,23 @@ example_inventory:unset_as_inventory_for(player)
 
 This will set the inventory formspec string to `""` and stop flow from
 processing inventory formspec input.
+
+### Rendering to a formspec
+
+This API should only be used when necessary and may have breaking changes in
+the future.
+
+Some APIs in other mods, such as sfinv, expect formspec strings, you can use
+this API to embed flow forms inside them. To use flow with these mods, you can
+call `form:render_to_formspec_string(player, ctx, embedded)`.
+
+ - When `embedded` is set, the `formspec_version` and `size` elements aren't
+   included in the returned formspec and are included in a third return value.
+ - Returns `formspec, process_event[, info]`
+ - The `process_event(fields)` callback will return true if the formspec should
+   be redrawn, where `render_to_formspec_string` should be called and the new
+   `process_event` should be used in the future. This function may return true
+   even if fields.quit is sent.
+
+
+**Do not use this API with node meta formspecs, it can and will break!**

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ player. Elements hidden this way will still take up space like with
 These features might be broken in the future.
 
 <details>
-<summary><h3><code>no_prepend[]</code></h3></summary>
+<summary><b><code>no_prepend[]</code></b></summary>
 
 You can set `no_prepend = true` on the "root" element to disable formspec
 prepends.
@@ -402,7 +402,7 @@ end)
 ![Screenshot](https://user-images.githubusercontent.com/3182651/212222545-baee3669-15cd-410d-a638-c63b65a8811b.png)
 
 </details><details>
-<summary><h3>Using a form as an inventory</h3></summary>
+<summary><b>Using a form as an inventory</b></summary>
 
 A form can be set as the player inventory. Flow internally generates the
 formspec and passes it to `player:set_inventory_formspec()`. This will
@@ -438,7 +438,7 @@ This will set the inventory formspec string to `""` and stop flow from
 processing inventory formspec input.
 
 </details><details>
-<summary><h3>Rendering to a formspec</h3></summary>
+<summary><b>Rendering to a formspec</b></summary>
 
 This API should only be used when necessary and may have breaking changes in
 the future.

--- a/init.lua
+++ b/init.lua
@@ -880,11 +880,7 @@ function Form:render_to_formspec_string(player, ctx, standalone)
         end
         return fs_process_events(player, form_info, fields)
     end
-    if not standalone then
-        return fs, event, public_form_info
-    else
-        return fs, event
-    end
+    return fs, event, public_form_info
 end
 
 function Form:close(player)

--- a/init.lua
+++ b/init.lua
@@ -856,17 +856,13 @@ local render_to_formspec_auto_name_ids = {}
 function Form:render_to_formspec_string(player, ctx, embedded)
     local name = player:get_player_name()
     local info = minetest.get_player_information(name)
-    local tree, form_info = self:_render(
-        player,
-        ctx or {},
-        info and info.formspec_version,
-        render_to_formspec_auto_name_ids[name])
-    local public_form_info = {}
+    local tree, form_info = self:_render(player, ctx or {},
+        info and info.formspec_version, render_to_formspec_auto_name_ids[name])
+    local public_form_info
     if embedded then
         local size = table.remove(tree, 1)
-        public_form_info.w = size.w
-        public_form_info.h = size.h
-        public_form_info.formspec_version = tree.formspec_version
+        public_form_info = {w = size.w, h = size.h,
+            formspec_version = tree.formspec_version}
         tree.formspec_version = nil
     end
     local fs = assert(formspec_ast.unparse(tree))
@@ -877,13 +873,9 @@ function Form:render_to_formspec_string(player, ctx, embedded)
         -- the player is offline, unlike the _real_ formspec submission.
         local player = minetest.get_player_by_name(name)
         if not player then
-            minetest.log(
-                "warning",
-                "[flow] Player " ..
-                name ..
+            minetest.log("warning", "[flow] Player " .. name ..
                 " was offline when render_to_formspec_string event was" ..
-                " triggered. Events were not passed through."
-            )
+                " triggered. Events were not passed through.")
             return nil
         end
         return fs_process_events(player, form_info, fields)

--- a/init.lua
+++ b/init.lua
@@ -850,16 +850,16 @@ local fs_process_events
 -- Unique per-user to prevent players from making the counter wrap around for
 -- other players.
 local render_to_formspec_auto_name_ids = {}
--- if `standalone` is not true, then this won't output a "root" formspec, but
---   instead will output  formspec designed to be embedded along with the
---   information that was removed from the form
+-- if `standalone` is set, then this will return a standalone formspec,
+-- otherwise it instead will output formspec that can be embedded and a table
+-- with its size and target formspec version
 function Form:render_to_formspec_string(player, ctx, standalone)
     local name = player:get_player_name()
     local info = minetest.get_player_information(name)
     local tree, form_info = self:_render(player, ctx or {},
         info and info.formspec_version, render_to_formspec_auto_name_ids[name])
     local public_form_info
-    if standalone then
+    if not standalone then
         local size = table.remove(tree, 1)
         public_form_info = {w = size.w, h = size.h,
             formspec_version = tree.formspec_version}
@@ -880,7 +880,7 @@ function Form:render_to_formspec_string(player, ctx, standalone)
         end
         return fs_process_events(player, form_info, fields)
     end
-    if standalone then
+    if not standalone then
         return fs, event, public_form_info
     else
         return fs, event

--- a/init.lua
+++ b/init.lua
@@ -1004,6 +1004,7 @@ local function on_leaveplayer(player)
     local name = player:get_player_name()
     open_formspecs[name] = nil
     open_inv_formspecs[name] = nil
+    render_to_formspec_auto_name_ids[name] = nil
 end
 
 if DEBUG_MODE then

--- a/init.lua
+++ b/init.lua
@@ -824,7 +824,8 @@ function Form:set_as_inventory_for(player, ctx)
     player:set_inventory_formspec(fs)
 end
 
-local fs_process_events -- Declared here to be accessable by render_to_formspec_string
+-- Declared here to be accessable by render_to_formspec_string
+local fs_process_events
 
 -- Returns a tuple of string and function
 function Form:render_to_formspec_string(player, ctx)

--- a/init.lua
+++ b/init.lua
@@ -845,10 +845,22 @@ end
 -- Declared here to be accessable by render_to_formspec_string
 local fs_process_events
 
+-- Prevent collisions in forms, but also ensure they don't happen across
+-- mutliple embedded forms within a single parent.
+-- Unique per-user to prevent players from making the counter wrap around for
+-- other players.
+local render_to_formspec_auto_name_ids = {}
 -- Returns a tuple of string and function
 function Form:render_to_formspec_string(player, ctx)
-    local fs, form_info = prepare_form(self, player, nil, ctx or {})
     local name = player:get_player_name()
+    local fs, form_info = prepare_form(
+        self,
+        player,
+        nil,
+        ctx or {},
+        render_to_formspec_auto_name_ids[name]
+    )
+    render_to_formspec_auto_name_ids[name] = form_info.auto_name_id
     return fs, function (fields)
         -- Just in case the player goes offline, we should not keep the player
         -- reference. Nothing prevents the user from calling this function when

--- a/init.lua
+++ b/init.lua
@@ -783,12 +783,6 @@ local function show_form(self, player, formname, ctx, auto_name_id)
 end
 
 local next_formname = 0
-local function new_next_formname()
-    -- Form name collisions are theoretically possible but probably won't
-    -- happen in practice (and if they do the impact will be minimal)
-    next_formname = (next_formname + 1) % 2^53
-end
-
 function Form:show(player, ctx)
     if type(player) == "string" then
         minetest.log("warning",
@@ -800,7 +794,9 @@ function Form:show(player, ctx)
     -- Use a unique form name every time a new form is shown
     show_form(self, player, ("flow:%x"):format(next_formname), ctx or {})
 
-    new_next_formname()
+    -- Form name collisions are theoretically possible but probably won't
+    -- happen in practice (and if they do the impact will be minimal)
+    next_formname = (next_formname + 1) % 2^53
 end
 
 function Form:show_hud(player, ctx)
@@ -829,9 +825,7 @@ local fs_process_events
 
 -- Returns a tuple of string and function
 function Form:render_to_formspec_string(player, ctx)
-    local formname = ("flow:subform_%x"):format(next_formname)
-    new_next_formname()
-    local fs, form_info = prepare_form(self, player, formname, ctx or {})
+    local fs, form_info = prepare_form(self, player, nil, ctx or {})
     local name = player:get_player_name()
     return fs, function (fields)
         -- Just in case the player goes offline, we should not keep the player

--- a/init.lua
+++ b/init.lua
@@ -850,9 +850,9 @@ local fs_process_events
 -- Unique per-user to prevent players from making the counter wrap around for
 -- other players.
 local render_to_formspec_auto_name_ids = {}
--- if `standalone` is set, then this will return a standalone formspec,
--- otherwise it instead will output formspec that can be embedded and a table
--- with its size and target formspec version
+-- If `standalone` is set, this will return a standalone formspec, otherwise it
+-- will return a formspec that can be embedded and a table with its size and
+-- target formspec version
 function Form:render_to_formspec_string(player, ctx, standalone)
     local name = player:get_player_name()
     local info = minetest.get_player_information(name)

--- a/init.lua
+++ b/init.lua
@@ -932,7 +932,7 @@ function flow.make_gui(build_func)
     return setmetatable({_build = build_func}, form_mt)
 end
 
--- Declared locally above to be accessable to render_to_formspec_string
+-- Declared locally above to be accessible to render_to_formspec_string
 function fs_process_events(player, form_info, fields)
     local callbacks = form_info.callbacks
     local ctx = form_info.ctx

--- a/init.lua
+++ b/init.lua
@@ -937,7 +937,7 @@ function fs_process_events(player, form_info, fields)
                 -- large amount of data and very long strings have the
                 -- potential to break things. Please open an issue if you
                 -- (somehow) need to use longer text in fields.
-                local name = player:get_player_name()\
+                local name = player:get_player_name()
                 minetest.log("warning", "[flow] Player " .. name .. " tried" ..
                     " submitting a large field value (>60 kB), ignoring.")
             else

--- a/init.lua
+++ b/init.lua
@@ -842,7 +842,7 @@ function Form:set_as_inventory_for(player, ctx)
     player:set_inventory_formspec(fs)
 end
 
--- Declared here to be accessable by render_to_formspec_string
+-- Declared here to be accessible by render_to_formspec_string
 local fs_process_events
 
 -- Prevent collisions in forms, but also ensure they don't happen across

--- a/init.lua
+++ b/init.lua
@@ -850,16 +850,16 @@ local fs_process_events
 -- Unique per-user to prevent players from making the counter wrap around for
 -- other players.
 local render_to_formspec_auto_name_ids = {}
--- if `embedded` is true, then this won't output a "root" formspec, but instead
---   will output  formspec designed to be embedded along with the information
---   that was removed from the form
-function Form:render_to_formspec_string(player, ctx, embedded)
+-- if `standalone` is not true, then this won't output a "root" formspec, but
+--   instead will output  formspec designed to be embedded along with the
+--   information that was removed from the form
+function Form:render_to_formspec_string(player, ctx, standalone)
     local name = player:get_player_name()
     local info = minetest.get_player_information(name)
     local tree, form_info = self:_render(player, ctx or {},
         info and info.formspec_version, render_to_formspec_auto_name_ids[name])
     local public_form_info
-    if embedded then
+    if standalone then
         local size = table.remove(tree, 1)
         public_form_info = {w = size.w, h = size.h,
             formspec_version = tree.formspec_version}
@@ -880,7 +880,7 @@ function Form:render_to_formspec_string(player, ctx, embedded)
         end
         return fs_process_events(player, form_info, fields)
     end
-    if embedded then
+    if standalone then
         return fs, event, public_form_info
     else
         return fs, event

--- a/test.lua
+++ b/test.lua
@@ -356,7 +356,6 @@ describe("Flow", function()
             assert.equals(manual_spy_count, 1, "event passsed down only once")
             assert.equals(manual_spy[1], player, "player was first arg")
             assert.equals(manual_spy[2], ctx, "context was next")
-            assert.equals(manual_spy[3], fields.btn, "the value was last")
 
             minetest.get_player_by_name = nil
         end)

--- a/test.lua
+++ b/test.lua
@@ -326,7 +326,7 @@ describe("Flow", function()
             end
             local form = flow.make_gui(build_func)
             local player = stub_player("test_player")
-            local fs, _ = form:render_to_formspec_string(player, nil, true)
+            local fs = form:render_to_formspec_string(player, nil, true)
             test_render(build_func, fs)
         end)
         it("renders nearly the same output as manually calling _render when not standalone", function()
@@ -339,7 +339,7 @@ describe("Flow", function()
             end
             local form = flow.make_gui(build_func)
             local player = stub_player("test_player")
-            local fs, _, info = form:render_to_formspec_string(player, false)
+            local fs, _, info = form:render_to_formspec_string(player)
             test_render(
                 build_func,
                 ("formspec_version[%s]size[%s,%s]"):format(

--- a/test.lua
+++ b/test.lua
@@ -72,7 +72,7 @@ local gui = flow.widgets
 -- values and fix weird floating point offsets
 local function normalise_tree(tree)
     tree = formspec_ast.flatten(tree)
-    tree.formspec_version = 5
+    tree.formspec_version = 6
     return assert(formspec_ast.parse(formspec_ast.unparse(tree)))
 end
 
@@ -282,7 +282,6 @@ describe("Flow", function()
 
     it("registers inventory formspecs", function ()
         local stupid_simple_inv_expected =
-            "formspec_version[5]" ..
             "size[10.35,5.35]" ..
             "list[current_player;main;0.3,0.3;8,4]"
         local stupid_simple_inv = flow.make_gui(function (p, c)
@@ -300,7 +299,7 @@ describe("Flow", function()
     end)
 
     it("can still show a form when an inventory formspec is shown", function ()
-        local expected_one = "formspec_version[5]size[1.6,1.6]box[0.3,0.3;1,1;]"
+        local expected_one = "size[1.6,1.6]box[0.3,0.3;1,1;]"
         local one = flow.make_gui(function (p, c)
             return gui.Box{ w = 1, h = 1 }
         end)

--- a/test.lua
+++ b/test.lua
@@ -316,7 +316,7 @@ describe("Flow", function()
     end)
 
     describe("render_to_formspec_string", function ()
-        it("renders the same output as manually calling _render", function()
+        it("renders the same output as manually calling _render when standalone", function()
             local build_func = function()
                 return gui.VBox{
                     gui.Box{w = 1, h = 1},
@@ -328,6 +328,26 @@ describe("Flow", function()
             local player = stub_player("test_player")
             local fs, _ = form:render_to_formspec_string(player, nil, true)
             test_render(build_func, fs)
+        end)
+        it("renders nearly the same output as manually calling _render when not standalone", function()
+            local build_func = function()
+                return gui.VBox{
+                    gui.Box{w = 1, h = 1},
+                    gui.Label{label = "Test", align_h = "centre"},
+                    gui.Field{name = "4", label = "Test", align_v = "fill"}
+                }
+            end
+            local form = flow.make_gui(build_func)
+            local player = stub_player("test_player")
+            local fs, _, info = form:render_to_formspec_string(player, false)
+            test_render(
+                build_func,
+                ("formspec_version[%s]size[%s,%s]"):format(
+                    info.formspec_version,
+                    info.w,
+                    info.h
+                ) .. fs
+            )
         end)
         it("passes events through the callback function", function()
             local manual_spy

--- a/test.lua
+++ b/test.lua
@@ -282,6 +282,7 @@ describe("Flow", function()
 
     it("registers inventory formspecs", function ()
         local stupid_simple_inv_expected =
+            "formspec_version[6]" ..
             "size[10.35,5.35]" ..
             "list[current_player;main;0.3,0.3;8,4]"
         local stupid_simple_inv = flow.make_gui(function (p, c)
@@ -299,7 +300,7 @@ describe("Flow", function()
     end)
 
     it("can still show a form when an inventory formspec is shown", function ()
-        local expected_one = "size[1.6,1.6]box[0.3,0.3;1,1;]"
+        local expected_one = "formspec_version[6]size[1.6,1.6]box[0.3,0.3;1,1;]"
         local one = flow.make_gui(function (p, c)
             return gui.Box{ w = 1, h = 1 }
         end)
@@ -325,7 +326,7 @@ describe("Flow", function()
             end
             local form = flow.make_gui(build_func)
             local player = stub_player("test_player")
-            local fs, _ = form:render_to_formspec_string(player)
+            local fs, _ = form:render_to_formspec_string(player, nil, true)
             test_render(build_func, fs)
         end)
         it("passes events through the callback function", function()
@@ -348,7 +349,7 @@ describe("Flow", function()
                 return player
             end
             local ctx = {a = 1}
-            local _, trigger_event = form:render_to_formspec_string(player, ctx)
+            local _, trigger_event = form:render_to_formspec_string(player, ctx, true)
 
             local fields = {btn = 1}
             trigger_event(fields)

--- a/test.lua
+++ b/test.lua
@@ -345,6 +345,7 @@ describe("Flow", function()
             end)
             local player = stub_player("test_player")
             function minetest.get_player_by_name(name)
+                assert(name == "test_player")
                 return player
             end
             local ctx = { a = 1 }

--- a/test.lua
+++ b/test.lua
@@ -316,10 +316,10 @@ describe("Flow", function()
     end)
 
     describe("render_to_formspec_string", function ()
-        it("renders the same output as manually calling _render", function ()
-            local build_func = function (_, _)
+        it("renders the same output as manually calling _render", function()
+            local build_func = function()
                 return gui.VBox{
-                    gui.Box{ w = 1, h = 1 },
+                    gui.Box{w = 1, h = 1},
                     gui.Label{label = "Test", align_h = "centre"},
                     gui.Field{name = "4", label = "Test", align_v = "fill"}
                 }
@@ -330,17 +330,17 @@ describe("Flow", function()
             test_render(build_func, fs)
         end)
         it("passes events through the callback function", function()
-            local manual_spy = nil
+            local manual_spy
             local manual_spy_count = 0
             local buttonargs = {
                 label = "Click me!",
                 name = "btn",
                 on_event = function (...)
-                    manual_spy = { ... }
+                    manual_spy = {...}
                     manual_spy_count = manual_spy_count + 1
                 end
             }
-            local form = flow.make_gui(function ()
+            local form = flow.make_gui(function()
                 return gui.Button(buttonargs)
             end)
             local player = stub_player("test_player")
@@ -348,13 +348,13 @@ describe("Flow", function()
                 assert(name == "test_player")
                 return player
             end
-            local ctx = { a = 1 }
+            local ctx = {a = 1}
             local _, trigger_event = form:render_to_formspec_string(player, ctx)
 
-            local fields = { btn = 1 }
+            local fields = {btn = 1}
             trigger_event(fields)
 
-            assert.equals(manual_spy_count, 1, "event passsed down only once")
+            assert.equals(manual_spy_count, 1, "event passed down only once")
             assert.equals(manual_spy[1], player, "player was first arg")
             assert.equals(manual_spy[2], ctx, "context was next")
 


### PR DESCRIPTION
Adds `Form:render_to_formspec_string` function.

Abstracted:

- `Form:show` to seperate out the next_formspec logic into the new private `new_next_formname` function.
- `on_fs_input` to seperate out the callback logic into the new private `fs_process_events` function.

`Form:render_to_formspec_string` is a new public function, taking a player ref and a context. Makes use of `new_next_formname` to get a unique formname for debugging purposes. Returns a tuple of the formspec and a asdfs function, which accepts a `fields` reference. This function calls `fs_process_events` to trigger the form events, and returns a boolean indicating if the form should be redrawn.

see #3 

## TODO (before I mark ready for review)

- [x] Code
- [x] Unit tests
  - [x] standalone
  - [x] embedded
- [x] Review comments and concerns
- [x] Documentation