### PR TITLE
feat(flow.widgets): Add nil gui object

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,21 @@ gui.Label{label="I am centered!", align_h = "centre"},
 This applies to other elements as well, because using HBox and Spacer to centre
 elements creates unnecessary containers.
 
+#### `gui.Nil`
+
+A tool to allow for ternary-ish conditional widgets:
+
+```lua
+gui.VBox{
+    gui.Label{ label = "The box below is only present if the boolean is truthy" },
+    the_boolean and gui.Box{ color = "#FF0000" } or gui.Nil{},
+}
+```
+
+Use sparingly, flow still has to process each `Nil` object to be able to know to
+remove it, and thus could still slow things down. The fastest element is one
+that doesn't exist, and thus doesn't need processing.
+
 #### `gui.Stack`
 
 This container element places its children on top of each other. All child

--- a/init.lua
+++ b/init.lua
@@ -1176,7 +1176,7 @@ end
 -- for use in inline <bool> and <a> or <b> type inline ifs
 function gui.Nil(def)
     def.expand = false
-    return gui.Spacer(def)
+    return gui.Toolip(def)
 end
 
 -- Prevent any further modifications to the gui table

--- a/init.lua
+++ b/init.lua
@@ -1121,6 +1121,12 @@ function gui.Spacer(def)
     return def
 end
 
+-- for use in inline <bool> and <a> or <b> type inline ifs
+function gui.Nil(def)
+    def.expand = false
+    return gui.Spacer{def}
+end
+
 -- Prevent any further modifications to the gui table
 function gui_mt.__newindex()
     error("Cannot modifiy gui table")

--- a/init.lua
+++ b/init.lua
@@ -1173,10 +1173,10 @@ function gui.Spacer(def)
     return def
 end
 
--- for use in inline <bool> and <a> or <b> type inline ifs
+-- For use in inline <bool> and <a> or <b> type inline ifs
 function gui.Nil(def)
-    def.expand = false
-    return gui.Toolip(def)
+    def.visible = false
+    return gui.Tooltip(def)
 end
 
 -- Prevent any further modifications to the gui table

--- a/init.lua
+++ b/init.lua
@@ -1175,6 +1175,8 @@ end
 
 -- For use in inline <bool> and <a> or <b> type inline ifs
 function gui.Nil(def)
+    -- Tooltip elements are ignored when layouting and setting visible = false
+    -- ensures that the element won't get added to the resulting formspec
     def.visible = false
     return gui.Tooltip(def)
 end

--- a/init.lua
+++ b/init.lua
@@ -1124,7 +1124,7 @@ end
 -- for use in inline <bool> and <a> or <b> type inline ifs
 function gui.Nil(def)
     def.expand = false
-    return gui.Spacer{def}
+    return gui.Spacer(def)
 end
 
 -- Prevent any further modifications to the gui table

--- a/test.lua
+++ b/test.lua
@@ -282,11 +282,12 @@ describe("Flow", function()
 
     it("ignores gui.Nil", function()
         test_render(gui.VBox{
+            min_h = 5, -- Make sure gui.Nil doesn't expand
             gui.Box{w = 1, h = 1, color = "red"},
             gui.Nil{},
             gui.Box{w = 1, h = 1, color = "green"},
         }, [[
-            size[1.6,1.6]
+            size[1.6,5.6]
             box[0.3,0.3;1,1;red]
             box[0.3,1.5;1,1;green]
         ]])

--- a/test.lua
+++ b/test.lua
@@ -280,6 +280,18 @@ describe("Flow", function()
         ]])
     end)
 
+    it("ignores gui.Nil", function()
+        test_render(gui.VBox{
+            gui.Box{w = 1, h = 1, color = "red"},
+            gui.Nil{},
+            gui.Box{w = 1, h = 1, color = "green"},
+        }, [[
+            size[1.6,1.6]
+            box[0.3,0.3;1,1;red]
+            box[0.3,1.5;1,1;green]
+        ]])
+    end)
+
     it("registers inventory formspecs", function ()
         local stupid_simple_inv_expected =
             "formspec_version[6]" ..


### PR DESCRIPTION
Skipped over by rendering library, and not included in output formspec.

I've found a personal need to use it in (nearly) every (sufficiently complicated) form I've made with flow.