### PR TITLE
fix: bgcolor settings for root node

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -459,13 +459,16 @@ local function render_ast(node)
     if node.no_prepend then
         res[#res + 1] = {type = "no_prepend"}
     end
-    if node.fbgcolor then
-        -- TODO: Fix this
+    if node.fbgcolor or node.bgcolor or node.bg_fullscreen then
         res[#res + 1] = {
             type = "bgcolor",
-            bgcolor = node.fbgcolor,
-            fullscreen = true
+            bgcolor = node.bgcolor,
+            fbgcolor = node.fbgcolor,
+            fullscreen = node.bg_fullscreen
         }
+        node.bgcolor = nil
+        node.fbgcolor = nil
+        node.bg_fullscreen = nil
     end
 
     for field in formspec_ast.find(node, 'field') do

--- a/test.lua
+++ b/test.lua
@@ -94,6 +94,45 @@ local function test_render(build_func, output)
 end
 
 describe("Flow", function()
+    describe("bgcolor settings", function ()
+        it("renders bgcolor only correctly", function ()
+            test_render(gui.VBox{ bgcolor = "green" }, [[
+                size[0.6,0.6]
+                bgcolor[green]
+            ]])
+        end)
+        it("renders fbgcolor only correctly", function ()
+            test_render(gui.VBox{ fbgcolor = "green" }, [[
+                size[0.6,0.6]
+                bgcolor[;;green]
+            ]])
+        end)
+        it("renders both correctly", function ()
+            test_render(gui.VBox{ bgcolor = "orange", fbgcolor = "green" }, [[
+                size[0.6,0.6]
+                bgcolor[orange;;green]
+            ]])
+        end)
+        it("passes fullscreen setting", function ()
+            test_render(gui.VBox{ bg_fullscreen = true }, [[
+                size[0.6,0.6]
+                bgcolor[;true]
+            ]])
+        end)
+        it("passes fullscreen setting when string", function ()
+            test_render(gui.VBox{ bg_fullscreen = "both" }, [[
+                size[0.6,0.6]
+                bgcolor[;both]
+            ]])
+        end)
+        it("handles it all together", function ()
+            test_render(gui.VBox{ bgcolor = "blue", fbgcolor = "red", bg_fullscreen = "neither" }, [[
+                size[0.6,0.6]
+                bgcolor[blue;neither;red]
+            ]])
+        end)
+    end)
+
     it("renders labels correctly", function()
         test_render(gui.Label{label = "Hello world!"}, [[
             size[3.12,1]


### PR DESCRIPTION
Just noticed a todo that looked easy enough lol.

Not sold on `bg_fullscreen` as a name. I think it's less ambiguous than just `fullscreen`, but not sure what it should be.

---

semantics node: `fix:` might not be appropriate here. Arguably could be considered a feature, since new functionality is being added. Either way doesn't really matter I guess.