### PR TITLE
Fix a pwdfield bug.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -709,6 +709,7 @@ end
 
 local default_value_fields = {
     field = "default",
+    pwdfield = "default",
     textarea = "default",
     checkbox = "selected",
     dropdown = "selected_idx",


### PR DESCRIPTION
CODE:
``` lua
local gui = flow.widgets

local title = gui.Label{label = "JBanking", align_h = "centre", style = {font = "bold", font_size = "*1.5"}}

jbanking.create_formspec = flow.make_gui(function(player, ctx)
    local buttons_hbox = gui.Hbox{}
    table.insert_all(buttons_hbox, {
        gui.Button{name = "signin", label = "Sign-In Portal", w = 3, h = 1.125,
        on_event = function(player, ctx)
            --jbanking.signin_formspec:show(player)
        end},
        gui.Spacer{},
        gui.Button{name = "new_account", label = "Create", w = 3, h = 1.125,
        on_event = function(player, ctx)
            minetest.chat_send_all(ctx.form["jbanking:username"] .. " | " .. ctx.form["jbanking:password"])
        end},
    })
    return gui.VBox{
        title,
        gui.Label{label = "Account Creation Portal", align_h = "centre", style = {font = "italic", font_size = "*1"}},
        gui.Field{name = "jbanking:username", label = "Username:", h = 1.125},
        gui.Pwdfield{name = "jbanking:password", label = "Password:", h = 1.125},
        buttons_hbox,
    }
end)

jbanking.create_formspec:show(player)
```

The formspec loads up correctly, but when I try to submit the form, the game crashes and says that there is no `jbanking:password`. When I change the type from `gui.Pwdfield` to `gui.Field`, the formspec runs as normal.

The PR should fix this.